### PR TITLE
fixing GPU memory leak in order_1_approx

### DIFF
--- a/src/functional.py
+++ b/src/functional.py
@@ -165,7 +165,7 @@ def order_1_approx(
         inputs=inputs.to("cpu"),
         logits=outputs.logits.cpu(),
         metadata={
-            "Jh": weight @ h,
+            "Jh": (weight @ h).detach().clone(),
         },
     )
 

--- a/src/functional.py
+++ b/src/functional.py
@@ -160,8 +160,8 @@ def order_1_approx(
         z=z,
         z_layer=z_layer,
         z_index=z_index,
-        weight=weight,
-        bias=bias,
+        weight=weight.detach().clone(),
+        bias=bias.detach().clone(),
         inputs=inputs.to("cpu"),
         logits=outputs.logits.cpu(),
         metadata={


### PR DESCRIPTION
I find then when I run `scripts.sweep`, I get OOM errors. It looks like there's an explicit OOM error handling path in the code, suggesting this is a common occurrence for running this script.

It looks like this is related to the `order_1_approx()` function, and I find that by adding `.detach().clone()` to the `weight` and `bias` it seems to alleviate the issue and I no longer get the OOM errors. I suspect that the jacobian calculation may be leaving behind a computation graph on the GPU that doesn't get freed, and calling `.detach().clone()` fully separates the returned tensors from the computation graph allowing garbage collection to clean up GPU memory. This is just my guess though, and I haven't done a memory profile to prove that's what going on.