### PR TITLE
fixing default editor name in evaluate script

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--editor",
         choices=EDITORS,
-        default="lr",
+        default="invert-lre",
         help="editor to use",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR fixes the default editor param for the evaluate script, as the default value currently is invalid and errors. It looks like the editor names were renamed in https://github.com/chanind/relations/commit/b59ca1be29420edb95794330f77219a1619b68d5, but the param wasn't renamed in the evaluate arguments default to match.