### PR TITLE
fixing new hparams file loading

### DIFF
--- a/src/hparams.py
+++ b/src/hparams.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 
 from src import data, models
 from src.utils import env_utils
-from src.utils.typing import PathLike
+from src.utils.typing import Layer, PathLike
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -37,11 +37,11 @@ RelationHParamsT = TypeVar("RelationHParamsT", bound="RelationHParams")
 class RelationHParams(HParams):
     model_name: str
     relation_name: str
-    h_layer: int
+    h_layer: Layer
     beta: float
     rank: int | None = None
     z_layer: int | None = None
-    h_layer_edit: int | None = None
+    h_layer_edit: Layer | None = None
 
     def save(self, file: PathLike | None = None) -> None:
         if file is None:

--- a/tests/test_hparams.py
+++ b/tests/test_hparams.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from src.hparams import RelationHParams
+
+
+def test_RelationHParams_from_relation_with_non_int_edit_layer():
+    hparams = RelationHParams.from_relation("gptj", "name gender")
+    assert hparams is not None
+    assert hparams.h_layer_edit == "emb"
+
+
+def test_RelationHParams_can_load_all_relation_files():
+    # root dir + /hparams
+    hparams_dir = Path(__file__).parent.parent / "hparams"
+    models = ["gptj", "llama", "gpt2-xl"]
+    for model in models:
+        hparams_files = hparams_dir.glob(f"{model}/*.json")
+        # just to make sure we're finding real files
+        assert len(list(hparams_files)) > 10
+        for hparams_file in hparams_files:
+            print(hparams_file)
+            hparams = RelationHParams.from_json_file(hparams_file)
+            assert hparams is not None
+            assert hparams.model_name == model
+            assert hparams.relation_name.replace(" ", "_") in hparams_file.name


### PR DESCRIPTION
The current hparams files in main error when loaded, with the following error:

```
ValueError: invalid literal for int() with base 10: 'emb'
```

This is because the new files use the string "emb" as a layer sometimes, but the hparams file lists layers at `int` only. This PR fixes this loading error by updating the type for `h_layer` and `h_layer_edit` in the `RelationHParams` class, and adds test coverage to ensure that all hparams files are able to load successfully.