### PR TITLE
Fix list TypeError in demo.ipynb

### DIFF
--- a/demo/demo.ipynb
+++ b/demo/demo.ipynb
@@ -210,7 +210,7 @@
    ],
    "source": [
     "relation_name = relation_options.value\n",
-    "relation = dataset.filter(relation_names=[relation_name])[0]\n",
+    "relation = dataset.filter(relation_names=relation_name)[0]\n",
     "print(f\"{relation.name} -- {len(relation.samples)} samples\")\n",
     "print(\"------------------------------------------------------\")\n",
     "\n",
@@ -756,7 +756,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

Fixed a small bug that uses `[relation_name]` as an argument to `dataset.filter` instead of `relation_name` itself, which causes a TypeError: unhashable type list. Hope this helps :)

## Before Fix
```python
relation_name = relation_options.value
relation = dataset.filter(relation_names=[relation_name])[0]
print(f"{relation.name} -- {len(relation.samples)} samples")
print("------------------------------------------------------")
```

## After Fix
```python
relation_name = relation_options.value
relation = dataset.filter(relation_names=relation_name)[0]
print(f"{relation.name} -- {len(relation.samples)} samples")
print("------------------------------------------------------")
```